### PR TITLE
Added matrix functionality

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,6 +8,7 @@ import {
 } from '@companion-module/base'
 import { EmberClient, Model as EmberModel } from 'emberplus-connection'
 import { EmberPlusConfig } from './config'
+import { FeedbackId } from './feedback'
 
 export enum ActionId {
   SetValueInt = 'setValueInt',
@@ -18,6 +19,9 @@ export enum ActionId {
   MatrixConnect = 'matrixConnect',
   MatrixDisconnect = 'matrixDisconnect',
   MatrixSetConnection = 'matrixSetConnection',
+  Take = 'take',
+  SetSelectedSource = 'setSelectedSource',
+  SetSelectedTarget = 'setSelectedTarget',
 }
 
 const pathInput: CompanionInputFieldTextInput = {
@@ -93,9 +97,90 @@ const doMatrixAction =
     }
   }
 
+const doMatrixActionFunction = function (
+  self: InstanceBase<EmberPlusConfig>,
+  emberClient: EmberClient,
+  config: EmberPlusConfig,
+  selMatrix: number
+) {
+  if (
+    config.selectedSource &&
+    config.selectedDestination &&
+    config.matrices &&
+    config.selectedSource[selMatrix] !== -1 &&
+    config.selectedDestination[selMatrix] !== -1
+  ) {
+    self.log('debug', 'Get node ' + config.matrices[selMatrix])
+    emberClient
+      .getElementByPath(config.matrices[selMatrix])
+      .then((node) => {
+        // TODO - do we handle not found?
+        if (node && node.contents.type === EmberModel.ElementType.Matrix) {
+          self.log('debug', 'Got node on ' + selMatrix)
+          const target = config.selectedDestination[selMatrix]
+          const sources = [config.selectedSource[selMatrix]]
+          emberClient
+            .matrixConnect(node as EmberModel.NumberedTreeNode<EmberModel.Matrix>, target, sources)
+            .then((r) => self.log('debug', String(r)))
+            .catch((r) => self.log('debug', r))
+        } else {
+          self.log('warn', 'Matrix ' + selMatrix + ' not found or not a parameter')
+        }
+      })
+      .catch((reason) => self.log('debug', reason))
+  }
+}
+
+const doTake =
+  (self: InstanceBase<EmberPlusConfig>, emberClient: EmberClient, config: EmberPlusConfig) =>
+  (action: CompanionActionEvent): void => {
+    if (config.selectedDestination && config.selectedSource && config.matrices) {
+      if (
+        config.selectedDestination[Number(action.options['matrix'])] !== -1 &&
+        config.selectedSource[Number(action.options['matrix'])] !== -1
+      ) {
+        doMatrixActionFunction(self, emberClient, config, Number(action.options['matrix']))
+      } else {
+        self.log('debug', 'TAKE went wrong.')
+      }
+      self.log(
+        'debug',
+        'TAKE: selectedDest: ' +
+          config.selectedDestination[Number(action.options['matrix'])] +
+          ' selectedSource: ' +
+          config.selectedSource[Number(action.options['matrix'])] +
+          ' on matrix ' +
+          Number(action.options['matrix'])
+      )
+    }
+  }
+
+const setSelectedSource =
+  (self: InstanceBase<EmberPlusConfig>, emberClient: EmberClient, config: EmberPlusConfig) =>
+  (action: CompanionActionEvent): void => {
+    if (action.options['source'] != -1 && action.options['matrix'] != -1 && config.selectedSource) {
+      config.selectedSource[Number(action.options['matrix'])] = Number(action.options['source'])
+    }
+    self.log('debug', 'Take is: ' + config.take)
+    if (config.take) doMatrixActionFunction(self, emberClient, config, Number(action.options['matrix']))
+    self.checkFeedbacks(FeedbackId.SourceBackgroundSelected)
+    self.log('debug', 'setSelectedSource: ' + action.options['source'] + ' on Matrix: ' + action.options['matrix'])
+  }
+
+const setSelectedTarget =
+  (self: InstanceBase<EmberPlusConfig>, config: EmberPlusConfig) =>
+  (action: CompanionActionEvent): void => {
+    if (action.options['target'] != -1 && action.options['matrix'] != -1 && config.selectedDestination) {
+      config.selectedDestination[Number(action.options['matrix'])] = Number(action.options['target'])
+    }
+    self.checkFeedbacks(FeedbackId.TargetBackgroundSelected)
+    self.log('debug', 'setSelectedTarget: ' + action.options['target'] + ' on Matrix: ' + action.options['matrix'])
+  }
+
 export function GetActionsList(
   self: InstanceBase<EmberPlusConfig>,
-  emberClient: EmberClient
+  emberClient: EmberClient,
+  config: EmberPlusConfig
 ): CompanionActionDefinitions {
   const actions: { [id in ActionId]: CompanionActionDefinition | undefined } = {
     [ActionId.SetValueInt]: {
@@ -188,6 +273,69 @@ export function GetActionsList(
       name: 'Matrix Set Connection',
       options: [...matrixInputs],
       callback: doMatrixAction(self, emberClient, async (...args) => emberClient.matrixSetConnection(...args)),
+    },
+    [ActionId.Take]: {
+      name: 'Take',
+      options: [
+        {
+          type: 'number',
+          label: 'Matrix Number',
+          id: 'matrix',
+          required: true,
+          min: 0,
+          max: 0xffffffff,
+          default: 0,
+        },
+      ],
+      callback: doTake(self, emberClient, config),
+    },
+    [ActionId.SetSelectedSource]: {
+      name: 'Set Selected Source',
+      options: [
+        {
+          type: 'number',
+          label: 'Select Matrix Number',
+          id: 'matrix',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+        {
+          type: 'number',
+          label: 'Value',
+          id: 'source',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+      ],
+      callback: setSelectedSource(self, emberClient, config),
+    },
+    [ActionId.SetSelectedTarget]: {
+      name: 'Set Selected Target',
+      options: [
+        {
+          type: 'number',
+          label: 'Select Matrix Number',
+          id: 'matrix',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+        {
+          type: 'number',
+          label: 'Value',
+          id: 'target',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+      ],
+      callback: setSelectedTarget(self, config),
     },
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,11 @@ export const portDefault = 9000
 export interface EmberPlusConfig {
   host?: string
   port?: number
+  take?: boolean
+  selectedSource: number[]
+  selectedDestination: number[]
+  matrices?: string[]
+  matricesString?: string
 }
 
 export function GetConfigFields(): SomeCompanionConfigField[] {
@@ -27,6 +32,20 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
       max: 0xffff,
       step: 1,
       default: portDefault,
+    },
+    {
+      type: 'checkbox',
+      id: 'take',
+      label: 'Enable Auto-Take?',
+      width: 6,
+      default: false,
+    },
+    {
+      type: 'textinput',
+      id: 'matricesString',
+      label: 'Paths to matrices',
+      tooltip: 'Please seperate by comma',
+      width: 12,
     },
   ]
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,8 +6,6 @@ export interface EmberPlusConfig {
   host?: string
   port?: number
   take?: boolean
-  selectedSource: number[]
-  selectedDestination: number[]
   matrices?: string[]
   matricesString?: string
 }

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -6,8 +6,11 @@ import {
 } from '@companion-module/base'
 import { EmberClient } from 'emberplus-connection'
 import { EmberPlusConfig } from './config'
+import { EmberPlusState } from './state'
 
 export enum FeedbackId {
+  Take = 'take',
+  Clear = 'clear',
   SourceBackgroundSelected = 'sourceBackgroundSelected',
   TargetBackgroundSelected = 'targetBackgroundSelected',
 }
@@ -15,9 +18,35 @@ export enum FeedbackId {
 export function GetFeedbacksList(
   _self: InstanceBase<EmberPlusConfig>,
   _emberClient: EmberClient,
-  config: EmberPlusConfig
+  state: EmberPlusState
 ): CompanionFeedbackDefinitions {
   const feedbacks: { [id in FeedbackId]: CompanionFeedbackDefinition | undefined } = {
+    [FeedbackId.Take]: {
+      name: 'Take is possible',
+      description: 'Shows if there is take possible',
+      type: 'boolean',
+      defaultStyle: {
+        bgcolor: combineRgb(255, 255, 255),
+        color: combineRgb(255, 0, 0),
+      },
+      options: [],
+      callback: () => {
+        return state.selected.target != -1 && state.selected.source != -1 && state.selected.matrix != -1
+      },
+    },
+    [FeedbackId.Clear]: {
+      name: 'Clear is possible',
+      description: 'Changes when a selection is made.',
+      type: 'boolean',
+      defaultStyle: {
+        bgcolor: combineRgb(255, 255, 255),
+        color: combineRgb(255, 0, 0),
+      },
+      options: [],
+      callback: () => {
+        return state.selected.target != -1 || state.selected.source != -1 || state.selected.matrix != -1
+      },
+    },
     [FeedbackId.SourceBackgroundSelected]: {
       name: 'Source Background If Selected',
       description: 'Change Background of Source, when it is currently selected.',
@@ -49,7 +78,9 @@ export function GetFeedbacksList(
         },
       ],
       callback: (feedback) => {
-        return config.selectedSource[Number(feedback.options['matrix'])] == feedback.options['source']
+        return (
+          state.selected.source == feedback.options['source'] && state.selected.matrix == feedback.options['matrix']
+        )
       },
     },
     [FeedbackId.TargetBackgroundSelected]: {
@@ -83,7 +114,9 @@ export function GetFeedbacksList(
         },
       ],
       callback: (feedback) => {
-        return config.selectedDestination[Number(feedback.options['matrix'])] == feedback.options['target']
+        return (
+          state.selected.target == feedback.options['target'] && state.selected.matrix == feedback.options['matrix']
+        )
       },
     },
   }

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,14 +1,92 @@
-import { CompanionFeedbackDefinition, CompanionFeedbackDefinitions, InstanceBase } from '@companion-module/base'
-import { EmberPlusConfig } from './config'
+import {
+  CompanionFeedbackDefinition,
+  CompanionFeedbackDefinitions,
+  combineRgb,
+  InstanceBase,
+} from '@companion-module/base'
 import { EmberClient } from 'emberplus-connection'
+import { EmberPlusConfig } from './config'
 
-export enum FeedbackId {}
+export enum FeedbackId {
+  SourceBackgroundSelected = 'sourceBackgroundSelected',
+  TargetBackgroundSelected = 'targetBackgroundSelected',
+}
 
 export function GetFeedbacksList(
   _self: InstanceBase<EmberPlusConfig>,
-  _emberClient: EmberClient
+  _emberClient: EmberClient,
+  config: EmberPlusConfig
 ): CompanionFeedbackDefinitions {
-  const feedbacks: { [id in FeedbackId]: CompanionFeedbackDefinition | undefined } = {}
+  const feedbacks: { [id in FeedbackId]: CompanionFeedbackDefinition | undefined } = {
+    [FeedbackId.SourceBackgroundSelected]: {
+      name: 'Source Background If Selected',
+      description: 'Change Background of Source, when it is currently selected.',
+      type: 'boolean',
+      defaultStyle: {
+        // The default style change for a boolean feedback
+        // The user will be able to customise these values as well as the fields that will be changed
+        bgcolor: combineRgb(255, 0, 0),
+        color: combineRgb(0, 0, 0),
+      },
+      options: [
+        {
+          type: 'number',
+          label: 'Select Matrix Number',
+          id: 'matrix',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+        {
+          type: 'number',
+          label: 'Value',
+          id: 'source',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+      ],
+      callback: (feedback) => {
+        return config.selectedSource[Number(feedback.options['matrix'])] == feedback.options['source']
+      },
+    },
+    [FeedbackId.TargetBackgroundSelected]: {
+      name: 'Target Background if Selected',
+      description: 'Change Background of Target, when it is currently selected.',
+      type: 'boolean',
+      defaultStyle: {
+        // The default style change for a boolean feedback
+        // The user will be able to customise these values as well as the fields that will be changed
+        bgcolor: combineRgb(255, 0, 0),
+        color: combineRgb(0, 0, 0),
+      },
+      options: [
+        {
+          type: 'number',
+          label: 'Select Matrix Number',
+          id: 'matrix',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+        {
+          type: 'number',
+          label: 'Value',
+          id: 'target',
+          required: true,
+          min: -0,
+          max: 0xffffffff,
+          default: 0,
+        },
+      ],
+      callback: (feedback) => {
+        return config.selectedDestination[Number(feedback.options['matrix'])] == feedback.options['target']
+      },
+    },
+  }
 
   return feedbacks
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { InstanceBase, InstanceStatus, SomeCompanionConfigField, runEntrypoint } from '@companion-module/base'
 import { GetActionsList } from './actions'
 import { EmberPlusConfig, GetConfigFields } from './config'
+import { GetFeedbacksList } from './feedback'
 import { EmberClient } from 'emberplus-connection' // note - emberplus-conn is in parent repo, not sure if it needs to be defined as dependency
 
 /**
- * Companion instance class for the Behringer X32 Mixers.
+ * Companion instance class for generic EmBER+ Devices
  */
 class EmberPlusInstance extends InstanceBase<EmberPlusConfig> {
   private emberClient!: EmberClient
@@ -24,6 +25,7 @@ class EmberPlusInstance extends InstanceBase<EmberPlusConfig> {
     this.config = config
 
     this.setupEmberConnection()
+    this.setupMatrices()
 
     this.updateCompanionBits()
   }
@@ -55,7 +57,8 @@ class EmberPlusInstance extends InstanceBase<EmberPlusConfig> {
   }
 
   private updateCompanionBits(): void {
-    this.setActionDefinitions(GetActionsList(this, this.client))
+    this.setActionDefinitions(GetActionsList(this, this.client, this.config))
+    this.setFeedbackDefinitions(GetFeedbacksList(this, this.client, this.config))
   }
 
   private get client(): EmberClient {
@@ -89,6 +92,26 @@ class EmberPlusInstance extends InstanceBase<EmberPlusConfig> {
       this.updateStatus(InstanceStatus.ConnectionFailure)
       this.log('error', 'Error ' + e)
     })
+  }
+
+  private setupMatrices(): void {
+    this.config.selectedSource = []
+    this.config.selectedDestination = []
+
+    if (this.config.matricesString) {
+      this.config.matrices = this.config.matricesString.split(',')
+    }
+
+    if (this.config.matrices) {
+      for (let i = 0; i < this.config.matrices.length; i++) {
+        this.config.selectedSource[i] = -1
+      }
+    }
+    if (this.config.matrices) {
+      for (let i = 0; i < this.config.matrices.length; i++) {
+        this.config.selectedDestination[i] = -1
+      }
+    }
   }
 }
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,26 +1,71 @@
-import { CompanionPresetDefinitions, InstanceBase } from '@companion-module/base'
-import { EmberPlusConfig } from './config'
+import { CompanionPresetDefinitions, combineRgb } from '@companion-module/base'
 
-// interface CompanionPresetExt extends CompanionButtonPresetDefinition {
-//   feedbacks: Array<
-//     {
-//       type: FeedbackId
-//     } & CompanionButtonPresetDefinition['feedbacks'][0]
-//   >
-//   actions: Array<
-//     {
-//       action: ActionId
-//     } & CompanionPreset['actions'][0]
-//   >
-//   release_actions?: Array<
-//     {
-//       action: ActionId
-//     } & NonNullable<CompanionPreset['release_actions']>[0]
-//   >
-// }
-
-export function GetPresetsList(_instance: InstanceBase<EmberPlusConfig>): CompanionPresetDefinitions {
+export function GetPresetsList(): CompanionPresetDefinitions {
   const presets: CompanionPresetDefinitions = {}
+  presets['take'] = {
+    category: 'Actions\n(XY only)',
+    name: 'Take',
+    type: 'button',
+    style: {
+      text: 'Take',
+      size: '18',
+      color: combineRgb(255, 255, 255),
+      bgcolor: combineRgb(0, 0, 0),
+    },
+    feedbacks: [
+      {
+        feedbackId: 'take',
+        style: {
+          bgcolor: combineRgb(255, 0, 0),
+          color: combineRgb(255, 255, 255),
+        },
+        options: {},
+      },
+    ],
+    steps: [
+      {
+        down: [
+          {
+            actionId: 'take',
+            options: {},
+          },
+        ],
+        up: [],
+      },
+    ],
+  }
 
+  presets['clear'] = {
+    category: 'Actions\n(XY only)',
+    name: 'Clear',
+    type: 'button',
+    style: {
+      text: 'Clear',
+      size: '18',
+      color: combineRgb(128, 128, 128),
+      bgcolor: combineRgb(0, 0, 0),
+    },
+    feedbacks: [
+      {
+        feedbackId: 'clear',
+        style: {
+          bgcolor: combineRgb(255, 255, 255),
+          color: combineRgb(255, 0, 0),
+        },
+        options: {},
+      },
+    ],
+    steps: [
+      {
+        down: [
+          {
+            actionId: 'clear',
+            options: {},
+          },
+        ],
+        up: [],
+      },
+    ],
+  }
   return presets
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,17 @@
+export interface CurrentSelected {
+  target: number
+  source: number
+  matrix: number
+}
+
+export class EmberPlusState {
+  selected: CurrentSelected
+
+  constructor() {
+    this.selected = {
+      source: -1,
+      target: -1,
+      matrix: -1,
+    }
+  }
+}


### PR DESCRIPTION
I wanted to select sources and targets individually, like I do using a video matrix.
This Pull Request implements this feature by adding some things.
### Config:
- selectable matrixPaths
- AutoTake, when target is selected and new source is selected
### Actions
- select Source from Matrix specified in the config
- select target from Matrix specified in the config
- execute take on Matrix specified in the config
### Feedbacks
- show if specified source on matrix is selected
- show if specified target on matrix is selected

Tested with Riedels MediorNet.